### PR TITLE
Use createElement shim to fix deep recursion

### DIFF
--- a/packages/style/src/constants.js
+++ b/packages/style/src/constants.js
@@ -1,1 +1,0 @@
-export const STYLE_KEY = 'motion$style'

--- a/packages/style/src/fancyElement.js
+++ b/packages/style/src/fancyElement.js
@@ -1,0 +1,134 @@
+import React from 'react'
+import { css } from 'aphrodite/no-important'
+import { omit } from 'lodash'
+import { filterStyleKeys, filterParentStyleKeys } from './helpers'
+import { STYLE_KEY } from './constants'
+
+// factory that return the this.fancyElement helper
+export default (Child, parentStyles, styles, opts, getDynamicStyles, getDynamicSheets) => {
+  const hasOwnStyles = !!(Child.style || Child.theme)
+  const shouldTheme = hasOwnStyles && opts.themes
+
+  return function fancyElement(type, props, children) {
+    // only style tags from within current view
+    if (!props || props[STYLE_KEY] !== this[STYLE_KEY]) {
+      return React.createElement(type, props, children)
+    }
+
+    // <name $one $two /> keys
+    const propKeys = Object.keys(props)
+    const styleKeys = filterStyleKeys(propKeys)
+
+    // remove $
+    const activeKeys = styleKeys
+      .filter(key => props[key] !== false && typeof props[key] !== 'undefined')
+      .map(key => key.slice(1))
+
+    // tag + $props
+    // don't style <Components />!
+    const isTag = typeof type === 'string'
+    const name = type
+    const allKeys = isTag ? [name, ...activeKeys] : activeKeys
+    let finalKeys = [...allKeys]
+
+    // collect styles
+    let finalStyles = []
+
+    //
+    // theme styles
+    //
+    if (shouldTheme) {
+      const themeKeys = prop => allKeys.map(k => `${prop}-${k}`)
+      const addTheme = (keys, prop) => [...keys, ...themeKeys(prop)]
+
+      // direct
+      const themes = this.constructor.theme
+      const themeProps = themes && Object.keys(themes)
+
+      if (themes && themeProps.length) {
+        themeProps.forEach(prop => {
+          if (this.props[prop] === true) {
+            // static theme
+            finalKeys = addTheme(finalKeys, prop)
+          } else if (
+            typeof this.props[prop] !== 'undefined' &&
+            typeof styles.theme[prop] === 'function'
+          ) {
+            // dynamic themes
+            const dynStyles = styles.theme[prop](this.props[prop])
+            const dynKeys = Object.keys(dynStyles).filter(tag => allKeys.indexOf(tag) > -1)
+
+            if (dynKeys.length) {
+              const activeStyles = dynKeys.reduce((acc, cur) => ({ ...acc, [cur]: dynStyles[cur] }), {})
+              finalStyles = [...finalStyles, ...getDynamicSheets(activeStyles)]
+            }
+          }
+        })
+      }
+    }
+
+    //
+    // parent styles
+    //
+    let parentStyleKeys = []
+    if (parentStyles) {
+      parentStyleKeys = filterParentStyleKeys(propKeys)
+
+      if (parentStyleKeys.length) {
+        const keys = parentStyleKeys.map(k => k.replace('$$', ''))
+
+        // dynamic
+        if (parentStyles.dynamics) {
+          finalStyles = [
+            ...finalStyles,
+            ...getDynamicSheets(getDynamicStyles(keys, props, parentStyles.dynamics, '$$'))
+          ]
+        }
+
+        // static
+        if (parentStyles.statics) {
+          finalStyles = [
+            ...finalStyles,
+            ...keys.map(k => parentStyles.statics[k])
+          ]
+        }
+      }
+    }
+
+    //
+    // own styles
+    //
+    // static
+    if (hasOwnStyles) {
+      if (styles.statics) {
+        finalStyles = [...finalStyles, ...finalKeys.map(i => styles.statics[i])]
+      }
+
+      // dynamic
+      if (styles.dynamics && activeKeys.length) {
+        finalStyles = [
+          ...finalStyles,
+          ...getDynamicSheets(getDynamicStyles(activeKeys, props, styles.dynamics))
+        ]
+      }
+    }
+
+    //
+    // finish
+    //
+    // recreate child (without style props)
+    const newProps = omit(props, [...styleKeys, ...parentStyleKeys, STYLE_KEY])
+
+    if (finalStyles.length) {
+      // apply styles
+      newProps.className = css(...finalStyles)
+
+      // keep original classNames
+      if (props && props.className && typeof props.className === 'string') {
+        newProps.className += ` ${props.className}`
+      }
+    }
+
+    return React.createElement(type, newProps, children)
+  }
+}

--- a/packages/style/src/fancyElement.js
+++ b/packages/style/src/fancyElement.js
@@ -12,12 +12,12 @@ export default (Child, parentStyles, styles, opts, getDynamicStyles, getDynamicS
 
   return function fancyElement(type, props, ...children) {
     // check for no props, no this (functional component), or no style key match
-    if (!props || !this) {
+    if (!this) {
       return originalCreateElement(type, props, ...children)
     }
 
     // <name $one $two /> keys
-    const propKeys = Object.keys(props)
+    const propKeys = props ? Object.keys(props) : []
     const styleKeys = filterStyleKeys(propKeys)
 
     // remove $

--- a/packages/style/src/fancyElement.js
+++ b/packages/style/src/fancyElement.js
@@ -2,17 +2,18 @@ import React from 'react'
 import { css } from 'aphrodite/no-important'
 import { omit } from 'lodash'
 import { filterStyleKeys, filterParentStyleKeys } from './helpers'
-import { STYLE_KEY } from './constants'
+
+const originalCreateElement = React.createElement
 
 // factory that return the this.fancyElement helper
 export default (Child, parentStyles, styles, opts, getDynamicStyles, getDynamicSheets) => {
   const hasOwnStyles = !!(Child.style || Child.theme)
   const shouldTheme = hasOwnStyles && opts.themes
 
-  return function fancyElement(type, props, children) {
-    // only style tags from within current view
-    if (!props || props[STYLE_KEY] !== this[STYLE_KEY]) {
-      return React.createElement(type, props, children)
+  return function fancyElement(type, props, ...children) {
+    // check for no props, no this (functional component), or no style key match
+    if (!props || !this) {
+      return originalCreateElement(type, props, ...children)
     }
 
     // <name $one $two /> keys
@@ -117,7 +118,7 @@ export default (Child, parentStyles, styles, opts, getDynamicStyles, getDynamicS
     // finish
     //
     // recreate child (without style props)
-    const newProps = omit(props, [...styleKeys, ...parentStyleKeys, STYLE_KEY])
+    const newProps = omit(props, [...styleKeys, ...parentStyleKeys])
 
     if (finalStyles.length) {
       // apply styles
@@ -129,6 +130,6 @@ export default (Child, parentStyles, styles, opts, getDynamicStyles, getDynamicS
       }
     }
 
-    return React.createElement(type, newProps, children)
+    return originalCreateElement(type, newProps, ...children)
   }
 }

--- a/packages/style/src/index.js
+++ b/packages/style/src/index.js
@@ -1,15 +1,15 @@
-import React from 'react'
-import { StyleSheet, css } from 'aphrodite/no-important'
-import { omit, pickBy } from 'lodash'
-import { applyNiceStyles, flattenThemes, isFunc, filterStyleKeys, filterParentStyleKeys } from './helpers'
-import { STYLE_KEY } from './constants'
+import fancyElementFactory from './fancyElement'
+import { StyleSheet } from 'aphrodite/no-important'
+import { pickBy } from 'lodash'
+import { applyNiceStyles, flattenThemes, isFunc } from './helpers'
 
+// defaults
 const defaultOpts = {
   themes: true
 }
 
 module.exports = function motionStyle(opts = defaultOpts) {
-  // helpers
+  // option-based helpers
   const getDynamicStyles = (active: Array, props: Object, styles: Object, propPrefix = '$') => {
     const dynamicKeys = active.filter(k => styles[k] && typeof styles[k] === 'function')
     const dynamicsReduce = (acc, k) => ({ ...acc, [k]: styles[k](props[`${propPrefix}${k}`]) })
@@ -22,7 +22,7 @@ module.exports = function motionStyle(opts = defaultOpts) {
     return Object.keys(dynamics).map(k => sheet[k])
   }
 
-  const processStyles = (userStyles, theme) => {
+  const getStyles = (userStyles, theme) => {
     const styles = { ...userStyles, ...flattenThemes(theme) }
     const dynamics = pickBy(styles, isFunc)
     const statics = pickBy(styles, x => !isFunc(x))
@@ -36,142 +36,15 @@ module.exports = function motionStyle(opts = defaultOpts) {
 
   // decorator
   const decorator = (Child, parentStyles) => {
-    if (!Child.style && !parentStyles) return Child
-
-    const styles = processStyles(Child.style, opts.themes ? Child.theme : null)
-    const hasOwnStyles = !!(Child.style || Child.theme)
-
-    // add to Child.prototype, so the decorated class can access:
-    // this.fancyElement
-
-    Child.prototype.fancyElement = function(type, props, children) {
-      // only style tags from within current view
-      if (!props || props[STYLE_KEY] !== this[STYLE_KEY]) {
-        return React.createElement(type, props, children)
-      }
-
-      // <name $one $two /> keys
-      const propKeys = Object.keys(props)
-      const styleKeys = filterStyleKeys(propKeys)
-
-      // remove $
-      const activeKeys = styleKeys
-        .filter(key => props[key] !== false && typeof props[key] !== 'undefined')
-        .map(key => key.slice(1))
-
-      // tag + $props
-      // don't style <Components />!
-      const isTag = typeof type === 'string'
-      const name = type
-      const allKeys = isTag ? [name, ...activeKeys] : activeKeys
-      let finalKeys = [...allKeys]
-
-      // collect styles
-      let finalStyles = []
-
-      //
-      // theme styles
-      //
-      if (hasOwnStyles && opts.themes) {
-        const themeKeys = prop => allKeys.map(k => `${prop}-${k}`)
-        const addTheme = (keys, prop) => [...keys, ...themeKeys(prop)]
-
-        // direct
-        const themes = this.constructor.theme
-        const themeProps = themes && Object.keys(themes)
-
-        if (themes && themeProps.length) {
-          themeProps.forEach(prop => {
-            if (this.props[prop] === true) {
-              // static theme
-              finalKeys = addTheme(finalKeys, prop)
-            } else if (
-              typeof this.props[prop] !== 'undefined' &&
-              typeof styles.theme[prop] === 'function'
-            ) {
-              // dynamic themes
-              const dynStyles = styles.theme[prop](this.props[prop])
-              const dynKeys = Object.keys(dynStyles).filter(tag => allKeys.indexOf(tag) > -1)
-
-              if (dynKeys.length) {
-                const activeStyles = dynKeys.reduce((acc, cur) => ({ ...acc, [cur]: dynStyles[cur] }), {})
-                finalStyles = [...finalStyles, ...getDynamicSheets(activeStyles)]
-              }
-            }
-          })
-        }
-      }
-
-      //
-      // parent styles
-      //
-      let parentStyleKeys = []
-      if (parentStyles) {
-        parentStyleKeys = filterParentStyleKeys(propKeys)
-
-        if (parentStyleKeys.length) {
-          const keys = parentStyleKeys.map(k => k.replace('$$', ''))
-
-          // dynamic
-          if (parentStyles.dynamics) {
-            finalStyles = [
-              ...finalStyles,
-              ...getDynamicSheets(getDynamicStyles(keys, props, parentStyles.dynamics, '$$'))
-            ]
-          }
-
-          // static
-          if (parentStyles.statics) {
-            finalStyles = [
-              ...finalStyles,
-              ...keys.map(k => parentStyles.statics[k])
-            ]
-          }
-        }
-      }
-
-      //
-      // own styles
-      //
-      // static
-      if (hasOwnStyles) {
-        if (styles.statics) {
-          finalStyles = [...finalStyles, ...finalKeys.map(i => styles.statics[i])]
-        }
-
-        // dynamic
-        if (styles.dynamics && activeKeys.length) {
-          finalStyles = [
-            ...finalStyles,
-            ...getDynamicSheets(getDynamicStyles(activeKeys, props, styles.dynamics))
-          ]
-        }
-      }
-
-      //
-      // finish
-      //
-      // recreate child (without style props)
-      const newProps = omit(props, [...styleKeys, ...parentStyleKeys, STYLE_KEY])
-
-      if (finalStyles.length) {
-        // apply styles
-        newProps.className = css(...finalStyles)
-
-        // keep original classNames
-        if (props && props.className && typeof props.className === 'string') {
-          newProps.className += ` ${props.className}`
-        }
-      }
-
-      return React.createElement(type, newProps, children)
-    }
-
+    // add to Child.prototype, so the decorated class can access: this.fancyElement
+    const styles = getStyles(Child.style, opts.themes ? Child.theme : null)
+    Child.prototype.fancyElement = fancyElementFactory(Child, parentStyles, styles, opts, getDynamicStyles, getDynamicSheets)
     return Child
   }
 
+  // parent decorator
   decorator.parent = styles => {
-    const parentStyles = processStyles(styles)
+    const parentStyles = getStyles(styles)
     return Child => decorator(Child, parentStyles)
   }
 

--- a/packages/style/src/index.js
+++ b/packages/style/src/index.js
@@ -41,163 +41,133 @@ module.exports = function motionStyle(opts = defaultOpts) {
     const styles = processStyles(Child.style, opts.themes ? Child.theme : null)
     const hasOwnStyles = !!(Child.style || Child.theme)
 
-    return class StyledComponent extends Child {
-      static displayName = Child.displayName || Child.name
+    // add to Child.prototype, so the decorated class can access:
+    // this.fancyElement
 
-      __styles = styles
-
-      render() {
-        return this.styleAll.call(this, super.render())
+    Child.prototype.fancyElement = function(type, props, children) {
+      // only style tags from within current view
+      if (!props || props[STYLE_KEY] !== this[STYLE_KEY]) {
+        return React.createElement(type, props, children)
       }
 
-      styleAll(children) {
-        if (!children || !Array.isArray(children) && !children.props) return children
+      // <name $one $two /> keys
+      const propKeys = Object.keys(props)
+      const styleKeys = filterStyleKeys(propKeys)
 
-        const styler = this.styleOne.bind(this)
-        if (Array.isArray(children)) {
-          return children.map(styler)
-        }
+      // remove $
+      const activeKeys = styleKeys
+        .filter(key => props[key] !== false && typeof props[key] !== 'undefined')
+        .map(key => key.slice(1))
 
-        const count = React.Children.count(children)
-        if (count > 1) {
-          return React.Children.map(children, styler)
-        }
+      // tag + $props
+      // don't style <Components />!
+      const isTag = typeof type === 'string'
+      const name = type
+      const allKeys = isTag ? [name, ...activeKeys] : activeKeys
+      let finalKeys = [...allKeys]
 
-        return styler(children)
-      }
+      // collect styles
+      let finalStyles = []
 
-      styleOne(child) {
-        if (Array.isArray(child)) return this.styleAll(child)
-        if (!child || !React.isValidElement(child)) return child
+      //
+      // theme styles
+      //
+      if (hasOwnStyles && opts.themes) {
+        const themeKeys = prop => allKeys.map(k => `${prop}-${k}`)
+        const addTheme = (keys, prop) => [...keys, ...themeKeys(prop)]
 
-        // only style tags from within current view
-        if (child.props[STYLE_KEY] !== this[STYLE_KEY]) return child
+        // direct
+        const themes = this.constructor.theme
+        const themeProps = themes && Object.keys(themes)
 
-        // <name $one $two /> keys
-        const propKeys = Object.keys(child.props)
-        const styleKeys = filterStyleKeys(propKeys)
+        if (themes && themeProps.length) {
+          themeProps.forEach(prop => {
+            if (this.props[prop] === true) {
+              // static theme
+              finalKeys = addTheme(finalKeys, prop)
+            } else if (
+              typeof this.props[prop] !== 'undefined' &&
+              typeof styles.theme[prop] === 'function'
+            ) {
+              // dynamic themes
+              const dynStyles = styles.theme[prop](this.props[prop])
+              const dynKeys = Object.keys(dynStyles).filter(tag => allKeys.indexOf(tag) > -1)
 
-        // remove $
-        const activeKeys = styleKeys
-          .filter(key => child.props[key] !== false && typeof child.props[key] !== 'undefined')
-          .map(key => key.slice(1))
-
-        // tag + $props
-        // don't style <Components />!
-        const isTag = typeof child.type === 'string'
-        const name = child.type
-        const allKeys = isTag ? [name, ...activeKeys] : activeKeys
-        let finalKeys = [...allKeys]
-
-        // collect styles
-        let finalStyles = []
-
-        //
-        // theme styles
-        //
-        if (hasOwnStyles && opts.themes) {
-          const themeKeys = prop => allKeys.map(k => `${prop}-${k}`)
-          const addTheme = (keys, prop) => [...keys, ...themeKeys(prop)]
-
-          // direct
-          const themes = this.constructor.theme
-          const themeProps = themes && Object.keys(themes)
-
-          if (themes && themeProps.length) {
-            themeProps.forEach(prop => {
-              if (this.props[prop] === true) {
-                // static theme
-                finalKeys = addTheme(finalKeys, prop)
-              } else if (
-                typeof this.props[prop] !== 'undefined' &&
-                typeof styles.theme[prop] === 'function'
-              ) {
-                // dynamic themes
-                const dynStyles = styles.theme[prop](this.props[prop])
-                const dynKeys = Object.keys(dynStyles).filter(tag => allKeys.indexOf(tag) > -1)
-
-                if (dynKeys.length) {
-                  const activeStyles = dynKeys.reduce((acc, cur) => ({ ...acc, [cur]: dynStyles[cur] }), {})
-                  finalStyles = [...finalStyles, ...getDynamicSheets(activeStyles)]
-                }
+              if (dynKeys.length) {
+                const activeStyles = dynKeys.reduce((acc, cur) => ({ ...acc, [cur]: dynStyles[cur] }), {})
+                finalStyles = [...finalStyles, ...getDynamicSheets(activeStyles)]
               }
-            })
-          }
-        }
-
-        //
-        // parent styles
-        //
-        let parentStyleKeys = []
-        if (parentStyles) {
-          parentStyleKeys = filterParentStyleKeys(propKeys)
-
-          if (parentStyleKeys.length) {
-            const keys = parentStyleKeys.map(k => k.replace('$$', ''))
-
-            // dynamic
-            if (parentStyles.dynamics) {
-              finalStyles = [
-                ...finalStyles,
-                ...getDynamicSheets(getDynamicStyles(keys, child.props, parentStyles.dynamics, '$$'))
-              ]
             }
-
-            // static
-            if (parentStyles.statics) {
-              finalStyles = [
-                ...finalStyles,
-                ...keys.map(k => parentStyles.statics[k])
-              ]
-            }
-          }
+          })
         }
+      }
 
-        //
-        // own styles
-        //
-        // static
-        if (hasOwnStyles) {
-          if (styles.statics) {
-            finalStyles = [...finalStyles, ...finalKeys.map(i => styles.statics[i])]
-          }
+      //
+      // parent styles
+      //
+      let parentStyleKeys = []
+      if (parentStyles) {
+        parentStyleKeys = filterParentStyleKeys(propKeys)
+
+        if (parentStyleKeys.length) {
+          const keys = parentStyleKeys.map(k => k.replace('$$', ''))
 
           // dynamic
-          if (styles.dynamics && activeKeys.length) {
+          if (parentStyles.dynamics) {
             finalStyles = [
               ...finalStyles,
-              ...getDynamicSheets(getDynamicStyles(activeKeys, child.props, styles.dynamics))
+              ...getDynamicSheets(getDynamicStyles(keys, props, parentStyles.dynamics, '$$'))
+            ]
+          }
+
+          // static
+          if (parentStyles.statics) {
+            finalStyles = [
+              ...finalStyles,
+              ...keys.map(k => parentStyles.statics[k])
             ]
           }
         }
-
-        //
-        // finish
-        //
-        // recreate child (without style props)
-        const { key, ref, props, type } = child
-        const newProps = omit(props, [...styleKeys, ...parentStyleKeys, STYLE_KEY])
-        if (ref) newProps.ref = ref
-        if (key) newProps.key = key
-
-        if (finalStyles.length) {
-          // apply styles
-          newProps.className = css(...finalStyles)
-
-          // keep original classNames
-          if (props && props.className && typeof props.className === 'string') {
-            newProps.className += ` ${props.className}`
-          }
-        }
-
-        // recurse to children
-        if (newProps && newProps.children) {
-          newProps.children = this.styleAll(child.props.children)
-        }
-
-        return React.createElement(type, newProps)
       }
+
+      //
+      // own styles
+      //
+      // static
+      if (hasOwnStyles) {
+        if (styles.statics) {
+          finalStyles = [...finalStyles, ...finalKeys.map(i => styles.statics[i])]
+        }
+
+        // dynamic
+        if (styles.dynamics && activeKeys.length) {
+          finalStyles = [
+            ...finalStyles,
+            ...getDynamicSheets(getDynamicStyles(activeKeys, props, styles.dynamics))
+          ]
+        }
+      }
+
+      //
+      // finish
+      //
+      // recreate child (without style props)
+      const newProps = omit(props, [...styleKeys, ...parentStyleKeys, STYLE_KEY])
+
+      if (finalStyles.length) {
+        // apply styles
+        newProps.className = css(...finalStyles)
+
+        // keep original classNames
+        if (props && props.className && typeof props.className === 'string') {
+          newProps.className += ` ${props.className}`
+        }
+      }
+
+      return React.createElement(type, newProps, children)
     }
+
+    return Child
   }
 
   decorator.parent = styles => {

--- a/packages/style/src/transform.js
+++ b/packages/style/src/transform.js
@@ -9,6 +9,21 @@ export default function({ types: t }: { types: Object }) {
         t.jSXIdentifier(STYLE_KEY),
         t.jSXExpressionContainer(t.identifier(styleKey))
       ))
+    },
+    ClassMethod(path: Object) {
+      if (path.node.key.name === 'render') {
+        path.node.body.body.unshift(
+          t.expressionStatement(
+            t.assignmentExpression('=',
+              t.memberExpression(
+                t.identifier('React'),
+                t.identifier('createElement')
+              ),
+              t.identifier('this.fancyElement.bind(this)')
+            )
+          )
+        )
+      }
     }
   }
 

--- a/packages/style/src/transform.js
+++ b/packages/style/src/transform.js
@@ -1,15 +1,7 @@
 /* @flow */
-import { STYLE_KEY } from './constants'
 
 export default function({ types: t }: { types: Object }) {
   const classBodyVisitor = {
-    JSXOpeningElement(path: Object, state: Object) {
-      const styleKey = state.get(STYLE_KEY)
-      path.node.attributes.push(t.jSXAttribute(
-        t.jSXIdentifier(STYLE_KEY),
-        t.jSXExpressionContainer(t.identifier(styleKey))
-      ))
-    },
     ClassMethod(path: Object) {
       if (path.node.key.name === 'render') {
         path.node.body.body.unshift(
@@ -42,10 +34,6 @@ export default function({ types: t }: { types: Object }) {
         })
         // -- Add a unique var to scope and all of JSX elements
         if (isMotionStyle) {
-          const id = path.scope.generateUidIdentifier(STYLE_KEY)
-          path.scope.push({ id, init: t.objectExpression([]) })
-          state.set(STYLE_KEY, id.name)
-          node.body.body.push(t.classProperty(t.identifier(STYLE_KEY), t.identifier(id.name)))
           path.traverse(classBodyVisitor, state)
         }
       }


### PR DESCRIPTION
Gets us better behavior.

Next step:

- [ ] Rather than require people to change pragma, we should change pragma ourselves only in `@style` decorated classes using our transform
- [ ] I think we don't need the motion$style keys anymore as well, because it should only call this.fancyElement which is self-contained already